### PR TITLE
Fix MCP naming in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Capsule CRM MCP Server
 
-A Model Control Protocol (MCP) server for Capsule CRM, allowing AI assistants to interact with your Capsule CRM data.
+A Model Context Protocol (MCP) server for Capsule CRM, allowing AI assistants to interact with your Capsule CRM data.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- update README intro to use "Model Context Protocol"

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684417e3e2d4832ba01ff492ecb74e06