### PR TITLE
Load .env file in server startup

### DIFF
--- a/capsule_mcp/server.py
+++ b/capsule_mcp/server.py
@@ -9,12 +9,21 @@ Run locally:
 import os
 from typing import Any, Dict, List, Optional
 
+from dotenv import load_dotenv
+
 import httpx
 from fastapi import FastAPI
 from fastmcp import FastMCP
 from fastmcp.server.auth import BearerAuthProvider
 from fastmcp.server.auth.providers.bearer import RSAKeyPair
 from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+
+# Load variables from a .env file if present before reading any env vars
+load_dotenv()
 
 # ---------------------------------------------------------------------------
 # Configuration


### PR DESCRIPTION
## Summary
- ensure Capsule server loads environment variables from `.env`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_684417e195b0832b9a59ffca5f973738