### PR TITLE
Update local server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Start the server with Uvicorn:
 uvicorn capsule_mcp.server:app --reload
 ```
 
-The API will be available at `http://localhost:8000/mcp`.
+The API will be available at `http://localhost:8000/mcp/`.
 
 ## Using with Claude Desktop
 
@@ -41,7 +41,7 @@ Add the server to your Claude Desktop configuration file (`config.json`):
 ```json
 {
   "mcpServers": [
-    {"name": "Capsule CRM", "url": "http://localhost:8000/mcp"}
+    {"name": "Capsule CRM", "url": "http://localhost:8000/mcp/"}
   ]
 }
 ```

--- a/add-to-cursor.html
+++ b/add-to-cursor.html
@@ -58,7 +58,7 @@
             <li>Under "MCP Servers", click "Add Server" and enter:
                 <ul>
                     <li>Name: <code>Capsule CRM</code></li>
-                    <li>URL: <code>http://localhost:8000/mcp</code></li>
+                    <li>URL: <code>http://localhost:8000/mcp/</code></li>
                 </ul>
             </li>
             <li>Click "Save" and restart Cursor</li>
@@ -69,7 +69,7 @@
         function addToCursor() {
             const serverConfig = {
                 name: "Capsule CRM",
-                url: "http://localhost:8000/mcp"
+                url: "http://localhost:8000/mcp/"
             };
             
             // Create a custom protocol URL that Cursor will handle


### PR DESCRIPTION
## Summary
- use slash-terminated MCP server URL in instructions
- update `add-to-cursor.html` demo page to use the same base path

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68441f889c58832b80214a742ec00fc9