### PR TITLE
Fix missing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "fastmcp>=2.2.5",
     "httpx>=0.25",
     "python-dotenv",
+    "fastapi>=0.68.0",
     "uvicorn[standard]",
     "pydantic>=2.0"
 ]


### PR DESCRIPTION
## Summary
- include fastapi in runtime deps so tests can run

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684423544eac832bb3380792f73ef777