### PR TITLE
Fix curl examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,15 @@ python -m pytest
 Manually test the server with `curl`
 
 Test the schema endpoint
-```
-curl -X POST http://localhost:8000/mcp \
+```bash
+curl -X POST http://localhost:8000/mcp/ \
   -H "Content-Type: application/json" \
   -d '{"type": "schema"}'
 ```
 
 Test listing contacts
-```curl -X POST http://localhost:8000/mcp \
+```bash
+curl -X POST http://localhost:8000/mcp/ \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -d '{


### PR DESCRIPTION
## Summary
- correct the `/mcp/` endpoint in README curl examples
- format the command snippets as bash for clarity

## Testing
- `pip install --break-system-packages -e .[dev]`
- `python3.12 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684437680d64832b9b8a988efc9900bb