### PR TITLE
Fix README curl examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ Test the schema endpoint
 ```bash
 curl -X POST http://localhost:8000/mcp/ \
   -H "Content-Type: application/json" \
-  -d '{"type": "schema"}'
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tools/list",
+    "id": 1
+  }'
 ```
 
 Test listing contacts
@@ -71,11 +76,12 @@ curl -X POST http://localhost:8000/mcp/ \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -d '{
-    "type": "tool",
-    "tool": "list_contacts",
-    "args": {
-      "page": 1,
-      "per_page": 10
-    }
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "params": {
+      "name": "list_contacts",
+      "arguments": {"page": 1, "per_page": 10}
+    },
+    "id": 1
   }'
 ```


### PR DESCRIPTION
## Summary
- correct the curl commands for retrieving the MCP schema and listing contacts

## Testing
- `PYENV_VERSION=3.10.17 python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684438c990a4832b93cbaaa7f585b333