### PR TITLE
Fix contact ordering and enable MCP stdio mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ pip install -e .
 
 ## Running the server
 
-Start the server with Uvicorn:
+**For Claude Desktop:** No manual server startup needed - Claude Desktop will launch the server automatically.
+
+**For standalone HTTP testing:** Start the server with Uvicorn:
 
 ```bash
 uvicorn capsule_mcp.server:app --reload
@@ -80,27 +82,7 @@ Add the server to your Claude Desktop configuration file (`claude_desktop_config
 {
   "mcpServers": {
     "capsule-crm": {
-      "command": "uvicorn",
-      "args": [
-        "capsule_mcp.server:app",
-        "--host", "0.0.0.0",
-        "--port", "8000"
-      ],
-      "env": {
-        "CAPSULE_API_TOKEN": "your_capsule_api_token_here"
-      }
-    }
-  }
-}
-```
-
-Alternatively, if you prefer to run the server manually and connect via HTTP:
-
-```json
-{
-  "mcpServers": {
-    "capsule-crm": {
-      "command": "python",
+      "command": "/usr/bin/python3",
       "args": [
         "/absolute/path/to/your/capsule-crm-mcp-server/capsule_mcp/server.py"
       ],
@@ -111,6 +93,11 @@ Alternatively, if you prefer to run the server manually and connect via HTTP:
   }
 }
 ```
+
+**Note:** You may need to adjust the Python path:
+- macOS/Linux: Try `/usr/bin/python3`, `/usr/local/bin/python3`, or run `which python3` to find your Python path
+- Windows: Try `C:\\Python311\\python.exe` or `python.exe` 
+- If using pyenv: Use the full path from `pyenv which python`
 
 **Important:** Replace `/absolute/path/to/your/capsule-crm-mcp-server/` with the actual path to this repository on your system.
 


### PR DESCRIPTION
## Summary
• Fixed contact ordering issue where list_contacts returned 2022 entries first
• Added new list_recent_contacts tool for proper date-based sorting
• Enabled MCP stdio mode for proper Claude Desktop integration
• Updated configuration guidance for different Python environments

## Changes Made

### Contact Ordering Fix
- **New Tool**: `list_recent_contacts` - Uses Capsule filters API to sort by `lastContactedOn` (descending)
- **Enhanced Tool**: `list_contacts` - Added `since` parameter for date filtering
- **Root Cause**: Basic `/parties` endpoint returns contacts in creation order, not activity order

### MCP Integration Fix  
- **Server Mode**: Changed from HTTP to stdio protocol for Claude Desktop
- **Configuration**: Updated to use direct Python execution instead of uvicorn
- **Python Paths**: Added guidance for pyenv, system Python, and Windows

### New Capabilities
- Get recent/active contacts instead of old 2022 entries
- Filter contacts by modification date
- Proper MCP protocol communication with Claude Desktop

## Test Plan
- [x] All existing tests pass
- [x] New tools respond correctly via MCP protocol
- [x] Claude Desktop integration works without HTTP server
- [x] Contact ordering shows recent entries first

## Usage Examples
- "Show me my most recent contacts" → `list_recent_contacts`
- "List contacts modified since January 2024" → `list_contacts` with `since`

🤖 Generated with [Claude Code](https://claude.ai/code)