### PR TITLE
Fix Cursor setup button to render HTML properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Add this to your Claude Desktop config file:
 
 **📋 Quick Setup:** 
 
-<a href="add-to-cursor.html" style="display: inline-block; background-color: #007AFF; color: white; padding: 10px 20px; text-decoration: none; border-radius: 6px; font-weight: 500;">🚀 Add to Cursor (Step-by-Step Guide)</a>
+<a href="https://htmlpreview.github.io/?https://github.com/fuzzylabs/capsule-mcp/blob/main/add-to-cursor.html" style="display: inline-block; background-color: #007AFF; color: white; padding: 10px 20px; text-decoration: none; border-radius: 6px; font-weight: 500;">🚀 Add to Cursor (Step-by-Step Guide)</a>
 
 Or add this to your Cursor MCP settings:
 


### PR DESCRIPTION
## Summary
- Update the Cursor setup button link to use htmlpreview.github.io
- Ensures the step-by-step guide displays as a proper webpage instead of raw HTML
- Fixes the issue where clicking the button only showed GitHub's HTML source view

## Test plan
- [ ] Click the button link and verify it opens a properly rendered HTML page
- [ ] Confirm the setup instructions are displayed with correct formatting
- [ ] Verify all styling and interactive elements work as expected

## Background
The previous implementation linked directly to the HTML file on GitHub, which only displayed the raw HTML source. This fix uses htmlpreview.github.io to properly render the HTML content as intended.

🤖 Generated with [Claude Code](https://claude.ai/code)