### PR TITLE
Fix Cursor button rendering and validation script compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ Add this to your Claude Desktop config file:
 
 **📋 Quick Setup:** 
 
-**[🚀 Add to Cursor (One-Click Install)](cursor://anysphere.cursor-deeplink/mcp/install?name=capsule-crm&config=eyJjYXBzdWxlLWNybSI6eyJjb21tYW5kIjoidXYiLCJhcmdzIjpbInJ1biIsIi0tZGlyZWN0b3J5IiwiL3BhdGgvdG8veW91ci9jYXBzdWxlLW1jcCIsInB5dGhvbiIsImNhcHN1bGVfbWNwL3NlcnZlci5weSJdLCJlbnYiOnsiQ0FQU1VMRV9BUElfVE9LRU4iOiJ5b3VyX2NhcHN1bGVfYXBpX3Rva2VuX2hlcmUifX19)**
+<a href="cursor://anysphere.cursor-deeplink/mcp/install?name=capsule-crm&config=eyJjYXBzdWxlLWNybSI6eyJjb21tYW5kIjoidXYiLCJhcmdzIjpbInJ1biIsIi0tZGlyZWN0b3J5IiwiL3BhdGgvdG8veW91ci9jYXBzdWxlLW1jcCIsInB5dGhvbiIsImNhcHN1bGVfbWNwL3NlcnZlci5weSJdLCJlbnYiOnsiQ0FQU1VMRV9BUElfVE9LRU4iOiJ5b3VyX2NhcHN1bGVfYXBpX3Rva2VuX2hlcmUifX19"
+   style="display: inline-block; background-color: #007AFF; color: white; padding: 10px 20px; text-decoration: none; border-radius: 6px; font-weight: 500;">
+   🚀 Add to Cursor (One-Click Install)
+</a>
 
 **Note:** After clicking the button, you'll need to:
 1. Update the path `/path/to/your/capsule-mcp` to your actual installation directory

--- a/scripts/generate-cursor-link.js
+++ b/scripts/generate-cursor-link.js
@@ -55,9 +55,22 @@ function updateReadme(deeplink) {
   
   let content = fs.readFileSync(readmePath, 'utf8');
   
-  // Find and replace the Cursor deeplink
-  const linkPattern = /(<a href="cursor:\/\/[^"]*"[^>]*>)/;
-  const match = content.match(linkPattern);
+  // Find and replace the Cursor deeplink - handle both single-line and multi-line HTML
+  const linkPatterns = [
+    /(<a href="cursor:\/\/[^"]*"[^>]*>.*?<\/a>)/s,  // Multi-line HTML
+    /(<a href="cursor:\/\/[^"]*"[^>]*>)/,           // Single-line HTML start
+  ];
+  
+  let match = null;
+  let patternUsed = null;
+  
+  for (const pattern of linkPatterns) {
+    match = content.match(pattern);
+    if (match) {
+      patternUsed = pattern;
+      break;
+    }
+  }
   
   if (match) {
     const oldLink = match[1];

--- a/scripts/validate-configs.py
+++ b/scripts/validate-configs.py
@@ -46,9 +46,19 @@ class ConfigValidator:
             
         content = readme_path.read_text()
         
-        # Find Cursor deeplink
-        pattern = r'cursor://anysphere\.cursor-deeplink/mcp/install\?name=([^&]+)&config=([^"]+)'
-        match = re.search(pattern, content)
+        # Find Cursor deeplink - handle both HTML and Markdown formats
+        # Markdown format: [text](cursor://anysphere.cursor-deeplink/mcp/install?name=X&config=Y)
+        # HTML format: <a href="cursor://anysphere.cursor-deeplink/mcp/install?name=X&config=Y">
+        patterns = [
+            r'\[.*?\]\(cursor://anysphere\.cursor-deeplink/mcp/install\?name=([^&]+)&config=([^)]+)\)',  # Markdown
+            r'cursor://anysphere\.cursor-deeplink/mcp/install\?name=([^&]+)&config=([^">\s]+)'  # HTML or direct
+        ]
+        
+        match = None
+        for pattern in patterns:
+            match = re.search(pattern, content)
+            if match:
+                break
         
         if not match:
             self.error("Cursor deeplink not found in README.md")


### PR DESCRIPTION
## Problem

The Cursor button was not rendering properly in GitHub and the validation script was failing after the format change.

### Issues
- ❌ Cursor button not visible in GitHub README
- ❌ CI validation failing: "Failed to decode Cursor deeplink config: Incorrect padding"
- ❌ Generation script not handling multiline HTML

## Solution

### 🔧 Button Rendering Fix
**Before (single line, not rendering):**
```html
<a href="cursor://very-long-url..." style="...">🚀 Add to Cursor</a>
```

**After (multiline, renders properly):**
```html
<a href="cursor://anysphere.cursor-deeplink/mcp/install?name=capsule-crm&config=..."
   style="display: inline-block; background-color: #007AFF; color: white; padding: 10px 20px; text-decoration: none; border-radius: 6px; font-weight: 500;">
   🚀 Add to Cursor (One-Click Install)
</a>
```

### 🔍 Validation Script Fix
- Added support for both markdown and HTML link formats
- Uses multiple regex patterns to find deeplink in any format
- Maintains backward compatibility

### 🔧 Generation Script Fix
- Updated to handle multiline HTML anchors
- Added multiple pattern matching for better reliability

## Testing

- ✅ **Local validation**: `python scripts/validate-configs.py` passes
- ✅ **Link generation**: `node scripts/generate-cursor-link.js` works correctly
- ✅ **Format compatibility**: Supports both HTML and markdown deeplink formats

## Expected Results

- 🎯 Cursor button now renders as a blue styled button in GitHub
- 🎯 CI validation tests should pass
- 🎯 Automation scripts continue to work correctly
- 🎯 One-click Cursor installation remains functional

🤖 Generated with [Claude Code](https://claude.ai/code)